### PR TITLE
Fix sample code to properly handle unicode strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,20 +180,30 @@ and Uint8Array:
 
 // string to uint array
 function text2ua(s) {
-    var ua = new Uint8Array(s.length);
-    for (var i = 0; i < s.length; i++) {
-        ua[i] = s.charCodeAt(i);
-    }
+    var escstr = encodeURIComponent(s);
+    var binstr = escstr.replace(/%([0-9A-F]{2})/g, function(match, p1) {
+        return String.fromCharCode('0x' + p1);
+    });
+    var ua = new Uint8Array(binstr.length);
+    Array.prototype.forEach.call(binstr, function (ch, i) {
+        ua[i] = ch.charCodeAt(0);
+    });
     return ua;
 }
 
 // uint array to string
 function ua2text(ua) {
-    var s = '';
-    for (var i = 0; i < ua.length; i++) {
-        s += String.fromCharCode(ua[i]);
-    }
-    return s;
+    var binstr = Array.prototype.map.call(ua, function (ch) {
+        return String.fromCharCode(ch);
+    }).join('');
+    var escstr = binstr.replace(/(.)/g, function (m, p) {
+        var code = p.charCodeAt(p).toString(16).toUpperCase();
+        if (code.length < 2) {
+            code = '0' + code;
+        }
+        return '%' + code;
+    });
+    return decodeURIComponent(escstr);
 }
 
 ```


### PR DESCRIPTION
The updated code will give the exact same output for unicode strings as you would get in node, python, ruby, Java, etc.

``` js
var buf = text2ua("I ½ ♥ 💩"); // [73, 32, 194, 189, 32, 226, 153, 165, 32, 240, 159, 146, 169]
new Buffer(buf).toString('utf8'); // "I ½ ♥ 💩"
```

``` js
var unicode = ua2text(new Uint8Array([73, 32, 194, 189, 32, 226, 153, 165, 32, 240, 159, 146, 169])); // "I ½ ♥ 💩"
Array.prototype.slice.call(new Buffer(unicode)); // [73, 32, 194, 189, 32, 226, 153, 165, 32, 240, 159, 146, 169]
```
